### PR TITLE
Adding semicolon to prevent error during concatenation;

### DIFF
--- a/angular-promise-extras.js
+++ b/angular-promise-extras.js
@@ -56,4 +56,4 @@
     })
   } ])
 
-})(window.angular)
+})(window.angular);


### PR DESCRIPTION
Hey hey,

We ran into some errors on build for our project (which includes a concatenation of all our dependencies) that was fixed by adding a semicolon.

Thanks,
- Chris
