### PR TITLE
Added semicolon to prevent concat issue

### DIFF
--- a/angular-promise-extras.js
+++ b/angular-promise-extras.js
@@ -56,4 +56,4 @@
     } ])
   } ])
 
-})(window.angular)
+})(window.angular);


### PR DESCRIPTION
This fixes the "Uncaught TypeError: (intermediate value)... is not a function" issue that can occur when angular-promise-extras is concatenated with other js files.
