### PR TITLE
Removed upper angular version limit from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/ohjames/angular-promise-extras#readme",
   "dependencies": {
-    "angular": ">=1.3.0 <1.7.0"
+    "angular": ">=1.3.0"
   },
   "devDependencies": {
     "jasmine-core": "^2.3.0",


### PR DESCRIPTION
This way `npm audit` will not warn for vulnerabilities that was fixed after 1.7.0 even if you have a later version of angular installed.