### PR TITLE
Add support for angular versions under the same major range

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,9 +14,9 @@
   "author": "James Pike <github@chilon.net>",
   "license": "ISC",
   "dependencies": {
-    "angular": ">=1.3.0 <1.7.0"
+    "angular": "^1.3.0"
   },
   "devDependencies": {
-    "angular-mocks": ">=1.3.0 <1.7.0"
+    "angular-mocks": "^1.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/ohjames/angular-promise-extras#readme",
   "dependencies": {
-    "angular": ">=1.3.0"
+    "angular": "^1.3.0"
   },
   "devDependencies": {
     "jasmine-core": "^2.3.0",


### PR DESCRIPTION
Change `angular` dependency include everything greater than `1.3.0` in the same major range.

This prevents using versions with vulnerability issues that were found for angular < 1.8.0:
- https://github.com/advisories/GHSA-89mq-4x47-5v83
- https://github.com/advisories/GHSA-mhp6-pxh8-r675